### PR TITLE
chore(qbx-storerobbery): remove console error by adding optional ref …

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -70,7 +70,7 @@ Keypad.Open = function(data) {
 Keypad.Close = function(data) {
     $("#keypad").css("display", "none");
     $.post(`https://${GetParentResourceName()}/PadLockClose`);
-    if (data.error) {
+    if (data?.error) {
         $.post(`https://${GetParentResourceName()}/CombinationFail`);
     }
 }


### PR DESCRIPTION
…to data obj

## Description
Check out the video for description. Essentially line 73 is firing off console error because we are referencing an undefined data obj param.
https://streamable.com/zgn40r
https://streamable.com/94nw7w

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
