### PR TITLE
fix(server/main): don't use old id in `playerJoining`

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -170,7 +170,7 @@ RegisterNetEvent('qbx_storerobbery:server:safeCracked', function()
     end)
 end)
 
-AddEventHandler('playerJoining', function(source)
+AddEventHandler('playerJoining', function()
     TriggerClientEvent('qbx_storerobbery:client:updatedRobbables', source, sharedConfig.registers, sharedConfig.safes)
 end)
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

The argument given to the `playerJoining` event is the old temporary player ID given by the `playerConnecting` event. The actual player ID is the global `source`.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
