### PR TITLE
Refactor animation functions and fix leo count check

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -15,7 +15,6 @@ end
 
 local function openingRegisterHandler(lockpickTime)
     openingRegister = true
-    lib.playAnim(cache.ped, 'veh@break_in@0h@p_m_one@', 'low_force_entry_ds', 3.0, 3.0, -1, 16, 0, false, false, false)
     CreateThread(function()
         while openingRegister do
             lib.playAnim(cache.ped, 'veh@break_in@0h@p_m_one@', 'low_force_entry_ds', 3.0, 3.0, -1, 16, 0, false, false, false)
@@ -33,9 +32,9 @@ end
 
 local function safeAnim()
     lib.requestAnimDict('amb@prop_human_bum_bin@idle_b')
-    lib.playAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'idle_d', 8.0, 8.0, -1, 50, 0, false, false, false)
+    TaskPlayAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'idle_d', 8.0, 8.0, -1, 50, 0, false, false, false)
     Wait(2500)
-    lib.playAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'exit', 8.0, 8.0, -1, 50, 0, false, false, false)
+    TaskPlayAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'exit', 8.0, 8.0, -1, 50, 0, false, false, false)
     RemoveAnimDict('amb@prop_human_bum_bin@idle_b')
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -33,9 +33,9 @@ end
 
 local function safeAnim()
     lib.requestAnimDict('amb@prop_human_bum_bin@idle_b')
-    TaskPlayAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'idle_d', 8.0, 8.0, -1, 50, 0, false, false, false)
+    lib.playAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'idle_d', 8.0, 8.0, -1, 50, 0, false, false, false)
     Wait(2500)
-    TaskPlayAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'exit', 8.0, 8.0, -1, 50, 0, false, false, false)
+    lib.playAnim(cache.ped, 'amb@prop_human_bum_bin@idle_b', 'exit', 8.0, 8.0, -1, 50, 0, false, false, false)
     RemoveAnimDict('amb@prop_human_bum_bin@idle_b')
 end
 
@@ -45,7 +45,7 @@ local function checkInteractStatus(register)
     end
 
     local leoCount = lib.callback.await('qbx_storerobbery:server:leoCount', false)
-    if leoCount > sharedConfig.minimumCops then
+    if leoCount >= sharedConfig.minimumCops then
         return true
     end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -15,9 +15,10 @@ end
 
 local function openingRegisterHandler(lockpickTime)
     openingRegister = true
+    lib.requestAnimDict('veh@break_in@0h@p_m_one@')
     CreateThread(function()
         while openingRegister do
-            lib.playAnim(cache.ped, 'veh@break_in@0h@p_m_one@', 'low_force_entry_ds', 3.0, 3.0, -1, 16, 0, false, false, false)
+            TaskPlayAnim(cache.ped, 'veh@break_in@0h@p_m_one@', 'low_force_entry_ds', 3.0, 3.0, -1, 16, 0, false, false, false)
             Wait(2000)
             lockpickTime = lockpickTime - 2000
             TriggerServerEvent('qbx_storerobbery:server:registerOpened', false)
@@ -25,6 +26,7 @@ local function openingRegisterHandler(lockpickTime)
             if lockpickTime <= 0 then
                 openingRegister = false
                 StopAnimTask(cache.ped, 'veh@break_in@0h@p_m_one@', 'low_force_entry_ds', 1.0)
+                RemoveAnimDict('veh@break_in@0h@p_m_one@')
             end
         end
     end)


### PR DESCRIPTION
## Description

This PR fixes the issue when minimumCops is set to 0 checkInteractStatus returns false, It also replaces all the TaskPlayAnim functions with lib.playAnim for better consitency.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
